### PR TITLE
Fix #14

### DIFF
--- a/standards/cstdefinexml200/source/standards/macros/define_sourceanalysisresults.sas
+++ b/standards/cstdefinexml200/source/standards/macros/define_sourceanalysisresults.sas
@@ -371,14 +371,20 @@
       create table armr_&_cstRandom
       as select
         unique armr.ResultIdentifier as OID,
-        case when not missing(armr.ParameterColumn)
-          then "IT."||kstrip(armr.Table)||"."||kstrip(armr.ParameterColumn)
-          else ""
-        end as ParameterOID,
+        armr_p.ParameterOID,
         armr.AnalysisReason,
         armr.AnalysisPurpose,
         armr.DisplayIdentifier as FK_AnalysisResultDisplays
-      from _cstSourceAnalysisResults_&_cstRandom armr
+      from 
+        _cstSourceAnalysisResults_&_cstRandom armr
+        left join (
+          select 
+            unique armr.ResultIdentifier,        
+            "IT."||kstrip(armr.Table)||"."||kstrip(armr.ParameterColumn) as ParameterOID
+          from _cstSourceAnalysisResults_&_cstRandom armr
+          where not missing(armr.ParameterColumn)
+          ) armr_p
+        on armr.ResultIdentifier = armr_p.ResultIdentifier
       order by OID
       ;
       %* TranslatedText (DisplayResults);
@@ -448,6 +454,7 @@
         unique armdoc.UUIDdoc as OID,
         armdoc.ResultIdentifier as FK_AnalysisResults
       from _cstSourceAnalysisResults_&_cstRandom armdoc
+      where not missing(armdoc.ResultDocumentation)
       ;
       %* TranslatedText (AnalysisDocumentation);
       create table doc_tt_&_cstRandom
@@ -457,6 +464,7 @@
         "AnalysisDocumentation" as parent,
         doc_tt.UUIDdoc as parentKey length=&_cstOIDLength
       from _cstSourceAnalysisResults_&_cstRandom doc_tt
+      where not missing(doc_tt.ResultDocumentation)
       ;
        %* analysisprogrammingcode;
       create table armcode_&_cstRandom

--- a/standards/cstdefinexml200/source/xsl-repository/DEFINE-XML/2.0.0/export/AnalysisProgrammingCode.xsl
+++ b/standards/cstdefinexml200/source/xsl-repository/DEFINE-XML/2.0.0/export/AnalysisProgrammingCode.xsl
@@ -12,36 +12,40 @@
 	
 	  <xsl:param name="parentKey" />
        
-    <xsl:for-each select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]">      
+    <xsl:for-each select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]">
+      <xsl:variable name="ProgrammingOID"><xsl:value-of select="OID"/></xsl:variable>
+      <xsl:variable name="hasCode" select="string-length(normalize-space(../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code)) &gt; 0"/>
+      <xsl:variable name="hasDocumentRefs" select="count(../DocumentRefs[parent = 'AnalysisProgrammingCode' and parentKey = $ProgrammingOID]) &gt; 0"/>
+      <xsl:if test="$hasCode or $hasDocumentRefs">
          
-      <xsl:element name="arm:ProgrammingCode">
-     
-        <xsl:if test="string-length(normalize-space(Context)) &gt; 0">
-          <xsl:attribute name="Context"><xsl:value-of select="Context"/></xsl:attribute>
-        </xsl:if>
- 
-        <xsl:variable name="str" select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code"/>
-
-        <xsl:if test="string-length(normalize-space(../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code)) &gt; 0">
-          <xsl:element name="arm:Code">
-            <xsl:call-template name="string-replace">
-              <xsl:with-param name="string" select="$str"/>
-              <xsl:with-param name="from" select="'\n'"/>
-              <xsl:with-param name="to"><xsl:text>&#10;</xsl:text></xsl:with-param>
+        <xsl:element name="arm:ProgrammingCode">
+       
+          <xsl:if test="string-length(normalize-space(Context)) &gt; 0">
+            <xsl:attribute name="Context"><xsl:value-of select="Context"/></xsl:attribute>
+          </xsl:if>
+   
+          <xsl:variable name="str" select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code"/>
+  
+          <xsl:if test="$hasCode">
+            <xsl:element name="arm:Code">
+              <xsl:call-template name="string-replace">
+                <xsl:with-param name="string" select="$str"/>
+                <xsl:with-param name="from" select="'\n'"/>
+                <xsl:with-param name="to"><xsl:text>&#10;</xsl:text></xsl:with-param>
+              </xsl:call-template>
+            </xsl:element>
+          </xsl:if>
+   
+          <xsl:if test="$hasDocumentRefs">
+            <xsl:call-template name="DocumentRefs">
+              <xsl:with-param name="parent">AnalysisProgrammingCode</xsl:with-param>
+              <xsl:with-param name="parentKey"><xsl:value-of select="OID"/></xsl:with-param>
             </xsl:call-template>
-          </xsl:element>
-        </xsl:if>
- 
-        <xsl:variable name="ProgrammingOID"><xsl:value-of select="OID"/></xsl:variable>
-        <xsl:if test="count(../DocumentRefs[parent = 'AnalysisProgrammingCode' and parentKey = $ProgrammingOID]) &gt; 0">
-          <xsl:call-template name="DocumentRefs">
-            <xsl:with-param name="parent">AnalysisProgrammingCode</xsl:with-param>
-            <xsl:with-param name="parentKey"><xsl:value-of select="OID"/></xsl:with-param>
-          </xsl:call-template>
-        </xsl:if>
-      
-      </xsl:element>
-    
+          </xsl:if>
+        
+        </xsl:element>
+        
+      </xsl:if>
     </xsl:for-each>
        	
   </xsl:template>

--- a/standards/cstdefinexml21/source/standards/macros/define_sourceanalysisresults.sas
+++ b/standards/cstdefinexml21/source/standards/macros/define_sourceanalysisresults.sas
@@ -373,14 +373,20 @@
       create table armr_&_cstRandom
       as select
         unique armr.ResultIdentifier as OID,
-        case when not missing(armr.ParameterColumn)
-          then "IT."||kstrip(armr.Table)||"."||kstrip(armr.ParameterColumn)
-          else ""
-        end as ParameterOID,
+        armr_p.ParameterOID,
         armr.AnalysisReason,
         armr.AnalysisPurpose,
         armr.DisplayIdentifier as FK_AnalysisResultDisplays
-      from _cstSourceAnalysisResults_&_cstRandom armr
+      from 
+        _cstSourceAnalysisResults_&_cstRandom armr
+        left join (
+          select 
+            unique armr.ResultIdentifier,        
+            "IT."||kstrip(armr.Table)||"."||kstrip(armr.ParameterColumn) as ParameterOID
+          from _cstSourceAnalysisResults_&_cstRandom armr
+          where not missing(armr.ParameterColumn)
+          ) armr_p
+        on armr.ResultIdentifier = armr_p.ResultIdentifier
       order by OID
       ;
       %* TranslatedText (DisplayResults);
@@ -450,6 +456,7 @@
         unique armdoc.UUIDdoc as OID,
         armdoc.ResultIdentifier as FK_AnalysisResults
       from _cstSourceAnalysisResults_&_cstRandom armdoc
+      where not missing(armdoc.ResultDocumentation)
       ;
       %* TranslatedText (AnalysisDocumentation);
       create table doc_tt_&_cstRandom
@@ -459,6 +466,7 @@
         "AnalysisDocumentation" as parent,
         doc_tt.UUIDdoc as parentKey length=&_cstOIDLength
       from _cstSourceAnalysisResults_&_cstRandom doc_tt
+      where not missing(doc_tt.ResultDocumentation)
       ;
        %* analysisprogrammingcode;
       create table armcode_&_cstRandom

--- a/standards/cstdefinexml21/source/xsl-repository/DEFINE-XML/2.1/export/AnalysisProgrammingCode.xsl
+++ b/standards/cstdefinexml21/source/xsl-repository/DEFINE-XML/2.1/export/AnalysisProgrammingCode.xsl
@@ -12,36 +12,38 @@
 	
 	  <xsl:param name="parentKey" />
        
-    <xsl:for-each select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]">      
+    <xsl:for-each select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]">
+      <xsl:variable name="ProgrammingOID"><xsl:value-of select="OID"/></xsl:variable>  
+      <xsl:if test="(count(../DocumentRefs[parent = 'AnalysisDocumentation' and parentKey = $ProgrammingOID]) &gt; 0) or (string-length(normalize-space(../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code)) &gt; 0)">
          
-      <xsl:element name="arm:ProgrammingCode">
-     
-        <xsl:if test="string-length(normalize-space(Context)) &gt; 0">
-          <xsl:attribute name="Context"><xsl:value-of select="Context"/></xsl:attribute>
-        </xsl:if>
- 
-        <xsl:variable name="str" select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code"/>
-
-        <xsl:if test="string-length(normalize-space(../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code)) &gt; 0">
-          <xsl:element name="arm:Code">
-            <xsl:call-template name="string-replace">
-              <xsl:with-param name="string" select="$str"/>
-              <xsl:with-param name="from" select="'\n'"/>
-              <xsl:with-param name="to"><xsl:text>&#10;</xsl:text></xsl:with-param>
+        <xsl:element name="arm:ProgrammingCode">
+       
+          <xsl:if test="string-length(normalize-space(Context)) &gt; 0">
+            <xsl:attribute name="Context"><xsl:value-of select="Context"/></xsl:attribute>
+          </xsl:if>
+   
+          <xsl:variable name="str" select="../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code"/>
+  
+          <xsl:if test="string-length(normalize-space(../AnalysisProgrammingCode[FK_AnalysisResults = $parentKey]/Code)) &gt; 0">
+            <xsl:element name="arm:Code">
+              <xsl:call-template name="string-replace">
+                <xsl:with-param name="string" select="$str"/>
+                <xsl:with-param name="from" select="'\n'"/>
+                <xsl:with-param name="to"><xsl:text>&#10;</xsl:text></xsl:with-param>
+              </xsl:call-template>
+            </xsl:element>
+          </xsl:if>
+   
+          <xsl:if test="count(../DocumentRefs[parent = 'AnalysisProgrammingCode' and parentKey = $ProgrammingOID]) &gt; 0">
+            <xsl:call-template name="DocumentRefs">
+              <xsl:with-param name="parent">AnalysisProgrammingCode</xsl:with-param>
+              <xsl:with-param name="parentKey"><xsl:value-of select="OID"/></xsl:with-param>
             </xsl:call-template>
-          </xsl:element>
-        </xsl:if>
- 
-        <xsl:variable name="ProgrammingOID"><xsl:value-of select="OID"/></xsl:variable>
-        <xsl:if test="count(../DocumentRefs[parent = 'AnalysisProgrammingCode' and parentKey = $ProgrammingOID]) &gt; 0">
-          <xsl:call-template name="DocumentRefs">
-            <xsl:with-param name="parent">AnalysisProgrammingCode</xsl:with-param>
-            <xsl:with-param name="parentKey"><xsl:value-of select="OID"/></xsl:with-param>
-          </xsl:call-template>
-        </xsl:if>
-      
-      </xsl:element>
-    
+          </xsl:if>
+        
+        </xsl:element>
+        
+      </xsl:if>
     </xsl:for-each>
        	
   </xsl:template>


### PR DESCRIPTION
fix #14 

- Duplicate arm:AnalysisResult
It seems that the issue is caused by the incomplete logic for creating unique records in cstOutputLibrary.analysisresults.

- Optional Elements Always Output
In the arm:Documentationcst, _cstOutputLibrary.analysisdocumentation creates records only when the mandatory element Source_analysisresults.ResultDocumentation is not empty.

In the arm:Programming Document, both arm:Code and def:DocumentRef are optional. Since the information for def:DocumentRef is included in Source_documents, I have modified the XSL to avoid compatibility issues when increasing the datasets referenced by the macro %define_sourceanalysisresults.

In my environment, Apache Ant cannot be used, so I could not follow the related procedures. 
And I wasn't  familiar with the DCO, so I made a mistake. I have corrected it by force-pushing to the forked repository. I apologize for any inconvenience this may have caused.

I created test data using the following code and confirmed that the elements were correct.

```sas
data Sampdata.Source_analysisresults ;
  set Sampdata.Source_analysisresults ;

/* Multi Record with ParameterColumn  */
  if ResultIdentifier = "AR.Table_14-3.01.R.2" then do ;
    TableJoinComment = "Dummy" ;
    output ;

    Table = "ADSL" ;
    WhereClause = 'SAFFL EQ "Y"' ;
    call missing(ParameterColumn, AnalysisVariables) ;
    output ;
  end ;
  else do ;
/*   empty arm:Documentation (Optional Element);*/
    if ResultIdentifier = "AR.Table_14-5.02.R.1" then call missing(ResultDocumentation) ;
    output ;
  end ;
run ; 

/*   empty arm:Documentation, ArmProgrammingCode (Optional Element);*/
data sampdata.Source_documents ;
  set sampdata.Source_documents ;
  if ResultIdentifier = "AR.Table_14-5.02.R.1" then delete ;
run ;
```